### PR TITLE
more tweaks, a note about further advances (in comment) and available at Wx/com/stlstartuplawyer.com/NDA/Form/Doc_x03.md

### DIFF
--- a/NDA/Source.md
+++ b/NDA/Source.md
@@ -1,40 +1,57 @@
-Doc.Title=MUTUAL NONDISCLOSURE Agreement
- Confidential_Information=<font color=“green”>Confidential Information</font>
- Agreement=<font color=“green”>Agreement</font>
- Recipient=<font color=“green”>Recipient</font>
- Discloser=<font color=“green”>Discloser</font>
+Doc.Title=Mutual Nondisclosure Agreement
+ 
+Confidential_Information=<font color=“green”>Confidential Information</font>
+
+Agreement=<font color=“green”>Agreement</font>
+
+Recipient=<font color=“green”>Recipient</font>
+
+Discloser=<font color=“green”>Discloser</font>
+
+Company=<font color=“green”>Company</font>
+
+Counterparty=<font color=“green”>Counterparty</font>
+
+Relationship=<font color=“green”>Relationship</font>
+
+P1.Handle={Company}
+
+P2.Handle={Counterparty}
 
 
-
-0.1.sec=This Mutual Nondisclosure Agreement (this “{Agreement}”) is made as of {EffectiveDate.YMD}, by and between {P1.N,E,A} (the “Company”), and {P2.N,E,A} (“Counterparty”).  Each party has disclosed and/or may further disclose its {Confidential Information} (as defined below) to the other in connection with the Relationship (as defined below) pursuant to the terms and conditions of this {Agreement}.  The term “{Discloser}” will refer to the Company whenever the context refers to the Company’s {Confidential Information} being disclosed to Counterparty, which is referred to as “{Recipient}” in that context.  Conversely, the term “{Discloser}” will refer to Counterparty whenever the context refers to Counterparty’s {Confidential Information} being disclosed to the Company, which is referred to as “{Recipient}” in that context. 
+0.1.sec=This {Doc.Title} (this “{Agreement}”) is made as of {EffectiveDate.YMD}, by and between {P1.N,E,A} (the “{Company}”), and {P2.N,E,A} (“{Counterparty}”).  Each party has disclosed and/or may further disclose its {Confidential_Information} (as defined below) to the other in connection with the {Relationship} (as defined below) pursuant to the terms and conditions of this {Agreement}.  The term “{Discloser}” will refer to the {Company} whenever the context refers to the {Company}’s {Confidential_Information} being disclosed to {Counterparty}, which is referred to as “{Recipient}” in that context.  Conversely, the term “{Discloser}” will refer to {Counterparty} whenever the context refers to {Counterparty}’s {Confidential_Information} being disclosed to the {Company}, which is referred to as “{Recipient}” in that context. 
 
 0.2.sec=RECITALS
 
-0.3.sec=The parties wish to {Purpose.Description} (the “Relationship”) in connection with which {Discloser} has disclosed and/or may further disclose its {Confidential Information} (as defined below) to {Recipient}.  This {Agreement} is intended to protect {Discloser}’s {Confidential Information} (including {Confidential Information} previously disclosed to {Recipient}) against unauthorized use or disclosure.
+0.3.sec=The parties wish to {Purpose.Description} (the “{Relationship}”) in connection with which {Discloser} has disclosed and/or may further disclose its {Confidential_Information} (as defined below) to {Recipient}.  This {Agreement} is intended to protect {Discloser}’s {Confidential_Information} (including {Confidential_Information} previously disclosed to {Recipient}) against unauthorized use or disclosure.
 
 0.4.sec={Agreement}
 
 0.5.sec=In consideration of the premises and mutual covenants, the parties agree as follows:
 
+Note=No title on the introduction:
+
+0.Sec={0.sec}
+
 0.=[Z/paras/s5]
 
 1.Ti=Definition of Confidential Information
 
-1.sec=“{Confidential Information}” means information and physical material not generally known or available outside {Discloser} and information and physical material entrusted to {Discloser} in confidence by third parties.  {Confidential Information} includes, without limitation:  technical data, trade secrets, know-how, research, product or service ideas or plans, software codes and designs, algorithms, developments, inventions, patent applications, laboratory notebooks, processes, formulas, techniques, mask works, engineering designs and drawings, hardware configuration information, {Agreement}s with third parties, lists of, or information relating to, employees and consultants of the {Discloser} (including, but not limited to, the names, contact information, jobs, compensation, and expertise of such employees and consultants), lists of, or information relating to, suppliers and customers, price lists, pricing methodologies, cost data, market share data, marketing plans, licenses, contract information, business plans, financial forecasts, historical financial data, budgets or other business information disclosed by {Discloser} (whether by oral, written, graphic or machine-readable format).
+1.sec=“{Confidential_Information}” means information and physical material not generally known or available outside {Discloser} and information and physical material entrusted to {Discloser} in confidence by third parties.  {Confidential_Information} includes, without limitation:  technical data, trade secrets, know-how, research, product or service ideas or plans, software codes and designs, algorithms, developments, inventions, patent applications, laboratory notebooks, processes, formulas, techniques, mask works, engineering designs and drawings, hardware configuration information, agreements with third parties, lists of, or information relating to, employees and consultants of the {Discloser} (including, but not limited to, the names, contact information, jobs, compensation, and expertise of such employees and consultants), lists of, or information relating to, suppliers and customers, price lists, pricing methodologies, cost data, market share data, marketing plans, licenses, contract information, business plans, financial forecasts, historical financial data, budgets or other business information disclosed by {Discloser} (whether by oral, written, graphic or machine-readable format).
 
 2.Ti=Nondisclosure of Confidential Information
 
-2.sec={Recipient} will not use any {Confidential Information} disclosed to it by {Discloser} for its own use or for any purpose other than to carry out discussions concerning, and the undertaking of, the Relationship.  {Recipient} will not disclose or permit disclosure of any {Confidential Information} of {Discloser} to third parties or to employees of {Recipient}, other than directors, officers, employees, consultants and agents of {Recipient} who are required to have the information in order to carry out the Relationship.  {Recipient} will take reasonable measures to protect the secrecy of and avoid disclosure or use of {Confidential Information} of {Discloser} in order to prevent it from falling into the public domain or the possession of persons other than those persons authorized under this {Agreement} to have the information. These measures will include the degree of care that {Recipient} utilizes to protect its own {Confidential Information} of a similar nature.  {Recipient} will notify {Discloser} of any misuse, misappropriation or unauthorized disclosure of {Confidential Information} of {Discloser} which may come to {Recipient}’s attention.
+2.sec={Recipient} will not use any {Confidential_Information} disclosed to it by {Discloser} for its own use or for any purpose other than to carry out discussions concerning, and the undertaking of, the Relationship.  {Recipient} will not disclose or permit disclosure of any {Confidential_Information} of {Discloser} to third parties or to employees of {Recipient}, other than directors, officers, employees, consultants and agents of {Recipient} who are required to have the information in order to carry out the Relationship.  {Recipient} will take reasonable measures to protect the secrecy of and avoid disclosure or use of {Confidential_Information} of {Discloser} in order to prevent it from falling into the public domain or the possession of persons other than those persons authorized under this {Agreement} to have the information. These measures will include the degree of care that {Recipient} utilizes to protect its own {Confidential_Information} of a similar nature.  {Recipient} will notify {Discloser} of any misuse, misappropriation or unauthorized disclosure of {Confidential_Information} of {Discloser} which may come to {Recipient}’s attention.
 
 3.Ti=Exceptions
 
-3.0.sec=Notwithstanding the above, {Recipient} will not have liability to {Discloser} with regard to any {Confidential Information} that the {Recipient} can prove:
+3.0.sec=Notwithstanding the above, {Recipient} will not have liability to {Discloser} with regard to any {Confidential_Information} that the {Recipient} can prove:
 
 3.1.sec=was in the public domain at the time it was disclosed or has entered the public domain through no fault of {Recipient};
 
 3.2.sec=was known to {Recipient}, without restriction, at the time of disclosure, as demonstrated by files in existence at the time of disclosure;
 
-3.3.sec=was independently developed by {Recipient} without any use of the {Confidential Information}, as demonstrated by files created at the time of such independent development; 
+3.3.sec=was independently developed by {Recipient} without any use of the {Confidential_Information}, as demonstrated by files created at the time of such independent development; 
 
 3.4.sec=is disclosed generally to third parties by {Discloser} without restrictions similar to those contained in this {Agreement}; 
 
@@ -48,31 +65,31 @@ Doc.Title=MUTUAL NONDISCLOSURE Agreement
 
 4.Ti=Return of Materials
 
-4.sec={Recipient} will, except as otherwise expressly authorized by {Discloser}, not make any copies or duplicates of any {Confidential Information}.  Any materials or documents that have been furnished by {Discloser} to {Recipient} in connection with the Relationship will be promptly returned by {Recipient}, accompanied by all copies of documentation, within ten (10) days after (a) the Relationship has been rejected or concluded or (b) the written request of {Discloser}.
+4.sec={Recipient} will, except as otherwise expressly authorized by {Discloser}, not make any copies or duplicates of any {Confidential_Information}.  Any materials or documents that have been furnished by {Discloser} to {Recipient} in connection with the {Relationship} will be promptly returned by {Recipient}, accompanied by all copies of documentation, within ten (10) days after (a) the Relationship has been rejected or concluded or (b) the written request of {Discloser}.
 
 5.Ti=No Rights Granted
 
-5.sec=Nothing in this {Agreement} will be construed as granting any rights under any patent, copyright or other intellectual property right of {Discloser}, nor will this {Agreement} grant {Recipient} any rights in or to {Discloser}’s {Confidential Information} other than the limited right to review such {Confidential Information} solely for the purpose of carrying out the Relationship.  Nothing in this {Agreement} requires the disclosure of any {Confidential Information}, which will be disclosed, if at all, solely at {Discloser}’s option.  Nothing in this {Agreement} requires the {Discloser} to proceed with the Relationship or any transaction in connection with which the {Confidential Information} may be disclosed.
+5.sec=Nothing in this {Agreement} will be construed as granting any rights under any patent, copyright or other intellectual property right of {Discloser}, nor will this {Agreement} grant {Recipient} any rights in or to {Discloser}’s {Confidential_Information} other than the limited right to review such {Confidential_Information} solely for the purpose of carrying out the Relationship.  Nothing in this {Agreement} requires the disclosure of any {Confidential_Information}, which will be disclosed, if at all, solely at {Discloser}’s option.  Nothing in this {Agreement} requires the {Discloser} to proceed with the Relationship or any transaction in connection with which the {Confidential_Information} may be disclosed.
 
 6.Ti=No Representations Made.  
 
-6.sec={Recipient} acknowledges that neither {Discloser}, nor any of its representatives, in the course of providing the {Confidential Information} is making any representation or warranty (express or implied) as to the accuracy or completeness of the information, and {Recipient} assumes full responsibility for all conclusions derived from the information.  {Recipient} will be entitled to, and will, rely solely on representations and warranties made in a definitive {Agreement}, if any, relating to the Relationship.
+6.sec={Recipient} acknowledges that neither {Discloser}, nor any of its representatives, in the course of providing the {Confidential_Information} is making any representation or warranty (express or implied) as to the accuracy or completeness of the information, and {Recipient} assumes full responsibility for all conclusions derived from the information.  {Recipient} will be entitled to, and will, rely solely on representations and warranties made in a definitive {Agreement}, if any, relating to the {Relationship}.
 
 7.Ti=No Reverse Engineering.  
 
-7.sec={Recipient} will not modify, reverse engineer, decompile, create other works from or disassemble any software programs contained in the {Confidential Information} of {Discloser} unless permitted in writing by {Discloser}. 
+7.sec={Recipient} will not modify, reverse engineer, decompile, create other works from or disassemble any software programs contained in the {Confidential_Information} of {Discloser} unless permitted in writing by {Discloser}. 
 
 8.Ti=Notice of Compelled Disclosure. 
 
-8.sec=In the event that {Recipient} or any person to whom they or their representatives transmit or have transmitted {Confidential Information} become legally compelled (by oral questions, interrogatories, requests for information or documents, subpoenas, civil investigative demands or otherwise) to disclose any {Confidential Information}, the {Recipient} will provide the {Discloser} with prompt written notice so that the {Discloser} may seek a protective order or other appropriate remedy, or both, or waive compliance with the provisions of this {Agreement}.  In the event that the {Discloser} is unable to obtain a protective order or other appropriate remedy, or if it so directs the {Recipient}, the {Recipient} will furnish only that portion of the {Confidential Information} that the {Recipient} is advised by written opinion of its counsel is legally required to be furnished by it and will exercise its reasonable best efforts to obtain reliable assurance that confidential treatment will be accorded such {Confidential Information}.
+8.sec=In the event that {Recipient} or any person to whom they or their representatives transmit or have transmitted {Confidential_Information} become legally compelled (by oral questions, interrogatories, requests for information or documents, subpoenas, civil investigative demands or otherwise) to disclose any {Confidential_Information}, the {Recipient} will provide the {Discloser} with prompt written notice so that the {Discloser} may seek a protective order or other appropriate remedy, or both, or waive compliance with the provisions of this {Agreement}.  In the event that the {Discloser} is unable to obtain a protective order or other appropriate remedy, or if it so directs the {Recipient}, the {Recipient} will furnish only that portion of the {Confidential_Information} that the {Recipient} is advised by written opinion of its counsel is legally required to be furnished by it and will exercise its reasonable best efforts to obtain reliable assurance that confidential treatment will be accorded such {Confidential_Information}.
 
 9.Ti=Common Interest Agreement.  
 
-9.sec=To the extent that any {Confidential Information} provided or made available may include material subject to the attorney-client privilege, work product doctrine or any other applicable privilege concerning pending or threatened legal proceedings or governmental investigations, {Recipient} and {Discloser} understand and agree that they have a commonality of interest with respect to such matters.  It is their desire and mutual understanding that the sharing of material is not intended to, and will not, waive or diminish in any way the confidentiality of the material or its continued protection under the attorney-client privilege, work product doctrine or other applicable privilege.  All {Confidential Information} provided or made available by {Discloser} that is entitled to protection under the attorney-client privilege, work product doctrine or other applicable privilege will remain entitled to that protection under these privileges, this {Agreement}, and under the joint defense doctrine.  Nothing in this {Agreement} obligates {Discloser} to reveal material subject to the attorney-client privilege, work product doctrine or any other applicable privilege.
+9.sec=To the extent that any {Confidential_Information} provided or made available may include material subject to the attorney-client privilege, work product doctrine or any other applicable privilege concerning pending or threatened legal proceedings or governmental investigations, {Recipient} and {Discloser} understand and agree that they have a commonality of interest with respect to such matters.  It is their desire and mutual understanding that the sharing of material is not intended to, and will not, waive or diminish in any way the confidentiality of the material or its continued protection under the attorney-client privilege, work product doctrine or other applicable privilege.  All {Confidential_Information} provided or made available by {Discloser} that is entitled to protection under the attorney-client privilege, work product doctrine or other applicable privilege will remain entitled to that protection under these privileges, this {Agreement}, and under the joint defense doctrine.  Nothing in this {Agreement} obligates {Discloser} to reveal material subject to the attorney-client privilege, work product doctrine or any other applicable privilege.
 
 10.Ti=Term.  
 
-10.sec=The foregoing commitments of each party will survive any termination of the Relationship between the parties, and will continue for a period terminating five (5) years from the date on which {Confidential Information} is last disclosed under this {Agreement}. 
+10.sec=The foregoing commitments of each party will survive any termination of the Relationship between the parties, and will continue for a period terminating five (5) years from the date on which {Confidential_Information} is last disclosed under this {Agreement}. 
 
 11.Ti=Independent Contractors.  
 
@@ -80,7 +97,7 @@ Doc.Title=MUTUAL NONDISCLOSURE Agreement
 
 12.Ti=Remedies.  
 
-12.sec=Each party’s obligations set forth in this {Agreement} are necessary and reasonable in order to protect {Discloser} and its business.  Due to the unique nature of {Discloser}’s {Confidential Information}, monetary damages may be inadequate to compensate {Discloser} for any breach by {Recipient} of its covenants and {Agreement}s set forth in this {Agreement}.  Accordingly, the parties each agree and acknowledge that any violation or threatened violation may cause irreparable injury to {Discloser}.  In addition to any other remedies that may be available, in law, in equity or otherwise, {Discloser} will be entitled to obtain injunctive relief against the threatened breach of this {Agreement} or the continuation of any breach by {Recipient}. 
+12.sec=Each party’s obligations set forth in this {Agreement} are necessary and reasonable in order to protect {Discloser} and its business.  Due to the unique nature of {Discloser}’s {Confidential_Information}, monetary damages may be inadequate to compensate {Discloser} for any breach by {Recipient} of its covenants and agreements set forth in this {Agreement}.  Accordingly, the parties each agree and acknowledge that any violation or threatened violation may cause irreparable injury to {Discloser}.  In addition to any other remedies that may be available, in law, in equity or otherwise, {Discloser} will be entitled to obtain injunctive relief against the threatened breach of this {Agreement} or the continuation of any breach by {Recipient}. 
 
 13.Ti=Miscellaneous
 
@@ -90,7 +107,7 @@ Doc.Title=MUTUAL NONDISCLOSURE Agreement
 
 13.2.Ti=Entire Agreement.  
 
-13.2.sec=This {Agreement} contains the complete {Agreement} of the parties regarding relating to the subject matter and supersedes all prior or contemporaneous discussions, understandings and {Agreement}s, whether oral or written.  This {Agreement} may be modified only in writing signed by both parties.  
+13.2.sec=This {Agreement} contains the complete {Agreement} of the parties regarding relating to the subject matter and supersedes all prior or contemporaneous discussions, understandings and agreements, whether oral or written.  This {Agreement} may be modified only in writing signed by both parties.  
 
 13.3.Ti=Non-Waiver and Binding Affect.
 
@@ -102,7 +119,7 @@ Doc.Title=MUTUAL NONDISCLOSURE Agreement
 
 13.5.Ti=Notices.
 
-13.5.sec=Any notice, demand or request required or permitted to be given under this {Agreement} will be in writing and will be deemed sufficient when delivered personally or by overnight courier or sent by email, or 48 hours after being deposited in the U.S. mail as certified or registered mail with postage prepaid, addressed to the party to be notified at the party’s address as set forth on the signature page, as subsequently modified by written notice, or if no address is specified on the signature page, at the most recent address set forth in the Company’s books and records. 
+13.5.sec=Any notice, demand or request required or permitted to be given under this {Agreement} will be in writing and will be deemed sufficient when delivered personally or by overnight courier or sent by email, or 48 hours after being deposited in the U.S. mail as certified or registered mail with postage prepaid, addressed to the party to be notified at the party’s address as set forth on the signature page, as subsequently modified by written notice, or if no address is specified on the signature page, at the most recent address set forth in the {Company}’s books and records. 
 
 13.6.Ti=Severability.
 
@@ -118,26 +135,16 @@ Doc.Title=MUTUAL NONDISCLOSURE Agreement
 
 13.=[Z/ol-a/8]
 
-
 90.1.sec={Signature Page Follows}
  
-90.2.sec=The parties have executed this Mutual Nondisclosure {Agreement} as of the date first above written.
+90.2.sec=The parties have executed this {Doc.Title} as of the date first above written.
 
 90.3.sec={P1.Sign.Block}<br>{P2.Sign.Block}
+
+90.Sec={90.sec}
 
 90.=[Z/paras/s3]
 
 =[Z/ol/13]
 
 DocBody={Doc}
-
-COMPANY		   COUNTERPARTY
-	
-By:	                                                          
-By:	                                                           
-Printed:	                                                           
-Printed:	                                                           
-Title:	                                                          
-Title:	                                                           
-Date:	                                                         
-Date:  


### PR DESCRIPTION
Next step could be to take, for instance, Section 3 and make it a new /Sec/Exclusions_v0.md.  That involves replacing it with:

3.=[Wx/com/stlstartuplawyer.com/NDA/Sec/Exclusions_v0.md]

and then (in Sec/Exclusions_v0.md) removing the leading 3. across all of the sections (the 3. is provided by prefixing).  We could then put in 

3.Sec={Exclude.Sec}

and then on mouseover each of the keys would read as Exclude.2.sec etc.   Can do that for all sections.  Can then change the outline to read <ol><li>{DefConfInfo.Sec}<li>{NotDisclose.Sec}<li>{Exclude.Sec}<li>....
